### PR TITLE
remove list dot from social list in footer

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -1100,6 +1100,7 @@ footer {
       flex-direction: row;
 
       .social {
+        list-style: none;
         margin-top: 0;
       }
     }


### PR DESCRIPTION
This removes the dot from the list:

<img width="66" alt="Bildschirmfoto 2022-09-06 um 08 16 24" src="https://user-images.githubusercontent.com/1510/188560395-46a64fcf-50ae-4338-93ac-4bf03234b05a.png">