### PR TITLE
fix(html): add missing 'alt' attribute to <img> elements

### DIFF
--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -27,7 +27,8 @@
                   {% if not talk.hideLink %}
                   <a href="/speakers/{{ talk.id }}" alt="speaker profile">
                     {% endif %}
-                    <img class="photo" src="/images/speakers/{{ talk.id }}.jpeg" />
+                    <img alt="{{ talk.speaker }} speaker profile" class="photo"
+                      src="/images/speakers/{{ talk.id }}.jpeg" />
                     {% if not talk.hideLink %}
                   </a>
                   {% endif %}
@@ -47,7 +48,8 @@
                   {% if not talk.hideLink %}
                   <a href="/speakers/{{ talk.id2 }}" alt="speaker profile">
                     {% endif %}
-                    <img class="photo" src="/images/speakers/{{ talk.id2 }}.jpeg" />
+                    <img alt="{{ talk.speaker2 }} speaker profile" class="photo"
+                      src="/images/speakers/{{ talk.id2 }}.jpeg" />
                     {% if not talk.hideLink %}
                   </a>
                   {% endif %}

--- a/templates/sections/our_speakers.html
+++ b/templates/sections/our_speakers.html
@@ -6,14 +6,14 @@
 <ul class="speakers">
   {% for speaker in section.extra.speakers %}
   <li>
-    <img src="/images/speakers/{{speaker.image}}.jpeg" class="photo" />
+    <img alt="{{ speaker.name }} speaker profile photo" src="/images/speakers/{{speaker.image}}.jpeg" class="photo" />
     <a href="/speakers/{{speaker.image}}">{{ speaker.name }}</a>
     {% if speaker.talk %}
     <p class="talk-title">{{ speaker.talk }}</p>
     {% endif %}
     <div class="links">
-      <a href="https://twitter.com/{{ speaker.twitter }}"><img src="/images/icons/twitter.svg" /></a>
-      <a href="{{ speaker.web }}"><img src="/images/icons/external-link.svg" /></a>
+      <a href="https://twitter.com/{{ speaker.twitter }}"><img alt="twitter icon" src="/images/icons/twitter.svg" /></a>
+      <a href="{{ speaker.web }}"><img alt="external link icon" src="/images/icons/external-link.svg" /></a>
     </div>
   </li>
   {% endfor %}

--- a/templates/sections/sponsors.html
+++ b/templates/sections/sponsors.html
@@ -12,7 +12,8 @@
       <h3 class="title premier-partners">Premier Partners</h3>
       {% for premier_partner in section.extra.sponsors.premier_partners %}
       <a href="{{ premier_partner.link }}" alt="{{ premier_partner.title }}">
-        <img src="/images/sponsors/premier_partners/{{ premier_partner.title }}.png" />
+        <img alt="{{ premier_partner.title }} logo"
+          src="/images/sponsors/premier_partners/{{ premier_partner.title }}.png" />
       </a>
       {% endfor %}
     </div>
@@ -21,7 +22,7 @@
       <h3 class="title partners">Partners</h3>
       {% for partner in section.extra.sponsors.partners %}
       <a href="{{ partner.link }}" alt="{{ partner.title }}">
-        <img src="/images/sponsors/partners/{{ partner.title }}.png" />
+        <img alt="{{ partner.title }} logo" src="/images/sponsors/partners/{{ partner.title }}.png" />
       </a>
       {% endfor %}
     </div>
@@ -30,7 +31,7 @@
       <h3 class="title supporters">Supporters</h3>
       {% for supporter in section.extra.sponsors.supporters %}
       <a href="{{ supporter.link }}" alt="{{ supporter.title }}">
-        <img src="/images/sponsors/supporters/{{ supporter.title }}.png" />
+        <img alt="{{ supporter.title }} logo" src="/images/sponsors/supporters/{{ supporter.title }}.png" />
       </a>
       {% endfor %}
     </div>

--- a/templates/sections/venue.html
+++ b/templates/sections/venue.html
@@ -2,7 +2,7 @@
   {% if section.extra.enable_venue %}
   <div class="location">
     <div class="hexagon">
-      <img class="image hexagon" src="/images/venue/loewesaal.jpeg" />
+      <img alt="Loewe Saal - Conference Venue" class="image hexagon" src="/images/venue/loewesaal.jpeg" />
     </div>
     <div class="location-info">
       <div class="title">
@@ -44,7 +44,7 @@
       <a href="https://ti.to/simplabs/eurorust-closing-dinner" alt="dinner registration">Register Here</a>
     </div>
     <div class="hexagon">
-      <img class="image hexagon" src="/images/venue/patio_restaurant.jpeg" />
+      <img alt="Patio Berlin - Closing Dinner Venue" class="image hexagon" src="/images/venue/patio_restaurant.jpeg" />
     </div>
   </div>
   {% endif %}

--- a/templates/speaker.html
+++ b/templates/speaker.html
@@ -26,10 +26,11 @@
 			<h3>Social Media</h3>
 			<div class="links">
 				{% if page.extra.twitter %}
-				<a href="https://twitter.com/{{ page.extra.twitter }}"><img src="/images/icons/twitter.svg"></a>
+				<a href="https://twitter.com/{{ page.extra.twitter }}"><img alt="twitter icon"
+						src="/images/icons/twitter.svg"></a>
 				{% endif %}
 				{% if page.extra.web %}
-				<a href="{{ page.extra.web }}"><img src="/images/icons/external-link.svg"></a>
+				<a href="{{ page.extra.web }}"><img alt="external link icon" src="/images/icons/external-link.svg"></a>
 				{% endif %}
 			</div>
 			{% endif %}


### PR DESCRIPTION
# Description
Add missing `alt` attribute to `<img>` elements

### Before
![image](https://user-images.githubusercontent.com/2574275/191808027-83b76a13-e3a8-4f59-a6df-8c787479ca41.png)

### After
![image](https://user-images.githubusercontent.com/2574275/191807915-e206459e-f177-4672-8fcb-e1b07997bab8.png)

# Context
Relates to https://github.com/simplabs/eurorust.eu/issues/61
