### PR TITLE
fix(html): add missing 'title' attribute to <iframe> elements

### DIFF
--- a/templates/sections/venue.html
+++ b/templates/sections/venue.html
@@ -18,7 +18,7 @@
         <iframe
           src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2427.3047420940543!2d13.3189768!3d52.527920300000005!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47a85115997640d3%3A0x1f1acdf149eee46a!2sLoewe%20Saal%20GmbH!5e0!3m2!1sen!2ses!4v1658744805623!5m2!1sen!2ses"
           width="100%" height="100%" style="border: 0" allowfullscreen="" loading="lazy"
-          referrerpolicy="no-referrer-when-downgrade"></iframe>
+          title="Loewe Saal location in Google Maps" referrerpolicy="no-referrer-when-downgrade"></iframe>
       </div>
     </div>
   </div>
@@ -39,7 +39,7 @@
         <iframe
           src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2427.6374587332193!2d13.348303200000002!3d52.5218998!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47a851a7320efc55%3A0x395b4fe181fca5b5!2sPatio!5e0!3m2!1sen!2ses!4v1661157096527!5m2!1sen!2ses"
           width="100%" height="100%" style="border: 0" allowfullscreen="" loading="lazy"
-          referrerpolicy="no-referrer-when-downgrade"></iframe>
+          title="Patio Berlin location in Google Maps" referrerpolicy="no-referrer-when-downgrade"></iframe>
       </div>
       <a href="https://ti.to/simplabs/eurorust-closing-dinner" alt="dinner registration">Register Here</a>
     </div>


### PR DESCRIPTION
# Description
Add `title` attribute to `<iframe>` elements

### Before
![image](https://user-images.githubusercontent.com/2574275/191809561-117b9b3f-3fdd-47ba-bb18-eb9d88d4c1c7.png)

### After
![image](https://user-images.githubusercontent.com/2574275/191809459-3b47ca45-1b25-4703-95a7-5d3c827bdaf4.png)

# Context
Relates to https://github.com/simplabs/eurorust.eu/issues/61