### PR TITLE
fix(frontpage): remove max-height for sponsor logos to preserve aspect ratio

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -606,21 +606,14 @@ body {
     justify-self: center;
     align-items: center;
 
-    --max-height-premier-partners: 8rem;
     --max-width-premier-partners: 18rem;
     --partner-size-ratio: 1.6;
     --supporter-size-ratio: 1.4;
 
-    --max-height-partners: calc(
-      var(--max-height-premier-partners) / var(--partner-size-ratio)
-    );
     --max-width-partners: calc(
       var(--max-width-premier-partners) / var(--partner-size-ratio)
     );
 
-    --max-height-supporters: calc(
-      var(--max-height-partners) / var(--supporter-size-ratio)
-    );
     --max-width-supporters: calc(
       var(--max-width-partners) / var(--supporter-size-ratio)
     );
@@ -630,17 +623,14 @@ body {
     }
 
     &.premier-partners img {
-      max-height: var(--max-height-premier-partners);
       max-width: var(--max-width-premier-partners);
     }
 
     &.partners img {
-      max-height: var(--max-height-partners);
       max-width: var(--max-width-partners);
     }
 
     &.supporters img {
-      max-height: var(--max-height-supporters);
       max-width: var(--max-width-supporters);
     }
   }


### PR DESCRIPTION
# Description
Remove `max-height` for Sponsor logos to preserve their aspect ratio. Now they are limited only by a `max-width` and use `width: 100%` when possible.

# Context
Fixes #180 

### More context
#183 