### PR TITLE
feat(sponsors): add support for 'image_format' for sponsors

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -10,26 +10,32 @@
 [[extra.sponsors.premier_partners]]
 	title="rust_foundation"
 	link="https://foundation.rust-lang.org/"
+	image_format="png"
 
 [[extra.sponsors.premier_partners]]
 	title="ferrocene"
 	link="https://ferrous-systems.com/"
+	image_format="png"
 
 [[extra.sponsors.premier_partners]]
 	title="arm"
 	link="https://www.arm.com/"
+	image_format="png"
 
 [[extra.sponsors.partners]]
 	title="google"
 	link="https://about.google/"
+	image_format="png"
 
 [[extra.sponsors.supporters]]
 	title="grafbase"
 	link="https://grafbase.com/"
+	image_format="png"
 
 [[extra.sponsors.supporters]]
 	title="oxidos"
 	link="https://oxidos.io"
+	image_format="png"
 
 [[extra.speakers]]
 	name="Daniel Stenberg"

--- a/templates/sections/sponsors.html
+++ b/templates/sections/sponsors.html
@@ -13,7 +13,7 @@
       {% for premier_partner in section.extra.sponsors.premier_partners %}
       <a href="{{ premier_partner.link }}" alt="{{ premier_partner.title }}">
         <img alt="{{ premier_partner.title }} logo"
-          src="/images/sponsors/premier_partners/{{ premier_partner.title }}.png" />
+          src="/images/sponsors/premier_partners/{{ premier_partner.title }}.{{ premier_partner.image_format }}" />
       </a>
       {% endfor %}
     </div>
@@ -22,7 +22,8 @@
       <h3 class="title partners">Partners</h3>
       {% for partner in section.extra.sponsors.partners %}
       <a href="{{ partner.link }}" alt="{{ partner.title }}">
-        <img alt="{{ partner.title }} logo" src="/images/sponsors/partners/{{ partner.title }}.png" />
+        <img alt="{{ partner.title }} logo"
+          src="/images/sponsors/partners/{{ partner.title }}.{{ partner.image_format }}" />
       </a>
       {% endfor %}
     </div>
@@ -31,7 +32,8 @@
       <h3 class="title supporters">Supporters</h3>
       {% for supporter in section.extra.sponsors.supporters %}
       <a href="{{ supporter.link }}" alt="{{ supporter.title }}">
-        <img alt="{{ supporter.title }} logo" src="/images/sponsors/supporters/{{ supporter.title }}.png" />
+        <img alt="{{ supporter.title }} logo"
+          src="/images/sponsors/supporters/{{ supporter.title }}.{{ supporter.image_format }}" />
       </a>
       {% endfor %}
     </div>


### PR DESCRIPTION
this opens the possibility to use different image extensions for logos
