### PR TITLE
Fix speaker profile links in 2022 schedule

### DIFF
--- a/templates/2022/schedule.html
+++ b/templates/2022/schedule.html
@@ -25,7 +25,7 @@
                 <div id="{{ talk.id }}" class="speaker">
                   {% if not talk.hideImage %}
                   {% if not talk.hideLink %}
-                  <a href="speakers/{{ talk.id }}" alt="speaker profile">
+                  <a href="/2022/speakers/{{ talk.id }}" alt="speaker profile">
                     {% endif %}
                     <img alt="{{ talk.speaker }} speaker profile" class="photo"
                       src="/images/speakers/{{ talk.id }}.jpeg" />
@@ -34,7 +34,7 @@
                   {% endif %}
                   {% endif %}
                   {% if not talk.hideLink %}
-                  <a href="speakers/{{ talk.id }}" alt="speaker profile">
+                  <a href="/2022/speakers/{{ talk.id }}" alt="speaker profile">
                     {% endif %}
                     <p class="table-entry name">{{ talk.speaker }}</p>
                     {% if not talk.hideLink %}
@@ -46,7 +46,7 @@
                 <div id="{{ talk.id2 }}" class="speaker">
                   {% if not talk.hideImage %}
                   {% if not talk.hideLink %}
-                  <a href="speakers/{{ talk.id2 }}" alt="speaker profile">
+                  <a href="/2022/speakers/{{ talk.id2 }}" alt="speaker profile">
                     {% endif %}
                     <img alt="{{ talk.speaker2 }} speaker profile" class="photo"
                       src="/images/speakers/{{ talk.id2 }}.jpeg" />
@@ -55,7 +55,7 @@
                   {% endif %}
                   {% endif %}
                   {% if not talk.hideLink %}
-                  <a href="speakers/{{ talk.id2 }}" alt="speaker profile" class="name">
+                  <a href="/2022/speakers/{{ talk.id2 }}" alt="speaker profile" class="name">
                     {% endif %}
                     <p class="table-entry name">{{ talk.speaker2 }}</p>
                     {% if not talk.hideLink %}


### PR DESCRIPTION
the links were pointing to /2022/schedule/speakers/daniel-stenberg but need to go to /2022/speakers/daniel-stenberg