### PR TITLE
ci(calibreapp/compress-image): run when it's NOT a draft PR

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     # Run Image Actions when JPG, JPEG, PNG or WebP files are added or changed.
     # See https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths for reference.
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - "**.jpg"
       - "**.jpeg"


### PR DESCRIPTION
# Description
Runs `calibreapp/image-actions` when the PR is **NOT** a draft PR.