### PR TITLE
fix title to include relevant info

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,7 @@
   <meta name="language" content="en" />
   <meta name="content-language" content="en" />
   <meta name="publisher" content="EuroRust" />
-  <title>EuroRust 2023</title>
+  <title>EuroRust 2023, October 12–13, Brussels & online</title>
   <link rel="stylesheet" href="/app.css" />
   <link rel="icon" type="image/x-icon" href="/images/icons/favicon.ico" />
   <link rel="apple-touch-icon" sizes="180x180" href="/images/icons/apple-touch-icon.png" />


### PR DESCRIPTION
This restores the relevant information regarding dates and location in the `<title>` tag:

> EuroRust 2023, October 12–13, Brussels & online