### PR TITLE
include "online" in header

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -7,6 +7,6 @@
 	</a>
 	<div>
 		<h2>OCT. 12-13 2023</h2>
-		<h2>BRUSSELS ∙ BELGIUM</h2>
+		<h2>BRUSSELS & ONLINE</h2>
 	</div>
 </header>

--- a/templates/partials/main_header.html
+++ b/templates/partials/main_header.html
@@ -3,7 +3,7 @@
     Oct. 12-13 2023
   </h2>
   <h2 class="location">
-    Brussels · Belgium
+    Brussels & online
   </h2>
   <h1 class="logo">
     <a class="link" href="/">


### PR DESCRIPTION
people know Brussels is in Belgium anyway and we want to make clear it's a hybrid event

<img width="726" alt="Bildschirm­foto 2023-02-20 um 14 58 28" src="https://user-images.githubusercontent.com/1510/220127452-5c51585c-e2af-4883-b448-467140c46b8f.png">