### PR TITLE
ci(compress-images): do not run the compress step if the last committer is a GitHub Action

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -23,7 +23,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           compressOnly: true
       - name: Create New Pull Request If Needed
-        if: steps.calibre.outputs.markdown != ''
+        if: steps.calibre.outputs.markdown != '' && github.event.commits[0].author.name != 'GitHubActions'
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4
         with:
           title: Compressed Images


### PR DESCRIPTION
# Description
Do not run `Compress Images` step if the last committer in the `main` branch was GitHub Action.

# Context
Fixes #252 

We want to prevent recursively compressed images after merging a PR of images compressed.

**Example of undesierd PR:**
https://github.com/mainmatter/eurorust.eu/pull/250 after this commit: https://github.com/mainmatter/eurorust.eu/commit/4f3fa805f4de558e229d6b4afcce7361930e44d0
