### PR TITLE
ci(compress-images): disable .webp image compression temporarily

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -7,7 +7,6 @@ on:
       - "**.jpg"
       - "**.jpeg"
       - "**.png"
-      - "**.webp"
 jobs:
   build:
     name: calibreapp/image-actions


### PR DESCRIPTION
# Description
Do not run compression for `.webp` iamges.

# Context
Reduces noise of undesired Image Compression PRs: https://github.com/mainmatter/eurorust.eu/pull/260

It will be properly fixed here: https://github.com/mainmatter/eurorust.eu/issues/257