### PR TITLE
build(renovate): add versioning upgrades for netlify.toml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,10 @@
 {
-  "extends": ["github>mainmatter/renovate-config:default.json5"]
+  "extends": ["github>mainmatter/renovate-config:default.json5"],
+  "regexManagers": [{
+    "commitMessageTopic": "Netlify config {{depName}}",
+    "fileMatch": [
+      "(^|/)netlify\\.toml$"
+    ],
+    "versioning": "docker"
+  }]
 }


### PR DESCRIPTION
# Description
Extend existing 'renovate' configuration to bump versions of dependencies inside `netlify.toml`

# Context
fixes #247

### Resources
- https://docs.renovatebot.com/modules/manager/cargo/#default-config
- https://msfjarvis.dev/posts/tips-and-tricks-for-using-renovate/#supporting-non-standard-dependency-declarations
- https://docs.renovatebot.com/modules/versioning/#supported-versioning
