### PR TITLE
fix(pill-button): add fixed margin-right of 20px to icons in pill-button

### DIFF
--- a/sass/mixins.scss
+++ b/sass/mixins.scss
@@ -120,7 +120,7 @@
       float: left;
       margin-bottom: 0px;
       margin-left: 0px;
-      margin-right: calc(#{$iconHeight} / 2.5);
+      margin-right: 20px;
 
       --maxHeightInPill: max(#{$iconHeight}, var(--font-size));
       --marginTopIcon: calc((var(--line-height) - var(--maxHeightInPill)) / 2);


### PR DESCRIPTION
# Description
Added a fixed distance of 20px to icons in all `pill-buttons`:

| before | after |
|--------|-------|
|  ![image](https://user-images.githubusercontent.com/2574275/226551508-79bdca78-8ecd-453b-be37-d00430c6d2f1.png) |   ![image](https://user-images.githubusercontent.com/2574275/226551187-4b9ba747-a589-4c17-aba9-4baca619c5d5.png)   |
| ![image](https://user-images.githubusercontent.com/2574275/226551560-d0ef0e48-73ff-44e4-a66d-49379f2e8676.png)  | ![image](https://user-images.githubusercontent.com/2574275/226551315-c8047e8d-3710-4ae2-b4e3-15b2fc0d42fb.png) |
| ![image](https://user-images.githubusercontent.com/2574275/226551653-a483129d-c538-41c6-9561-2744f13e3cce.png) | ![image](https://user-images.githubusercontent.com/2574275/226551412-a71cd1ce-f86c-40dd-92d9-f706d7631795.png) |

## [Preview Link](https://deploy-preview-283--eurorust.netlify.app/)

# Context
Adjusted design to use a fixed distance of `20px` in the context of [this comment](https://github.com/mainmatter/eurorust.eu/pull/267#issuecomment-1476123624)