### PR TITLE
feat(footer): changed CSS approach for separators in <footer> links

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -593,7 +593,8 @@ $atomium-bg-width: 1429px;
 
     @include desktop-only {
       grid-column: 1;
-      grid-row: 1 / 4;
+      grid-row-start: 1;
+      grid-row-end: 4;
     }
 
     .image-venue {
@@ -749,19 +750,24 @@ $atomium-bg-width: 1429px;
       line-height: 35px;
     }
 
-    li:nth-child(n + 2)::before {
+    li:not(:last-child)::after {
       content: "·";
-      margin-right: 10px;
+      margin-left: 10px;
       font-family: Poppins-Light;
       font-size: 15px;
       @include desktop-and-tablet-only {
         font-size: 18px;
       }
     }
+
+    li > p {
+      display: inline-block;
+    }
   }
 
   .meta {
-    grid-column: 1 / 3;
+    grid-column-start: 1;
+    grid-column-end: 3;
     @include mobile-only {
       grid-row: 1;
       grid-column: 1;
@@ -770,7 +776,8 @@ $atomium-bg-width: 1429px;
 
   hr {
     width: 100%;
-    grid-column: 1 / 3;
+    grid-column-start: 1;
+    grid-column-end: 3;
     @include mobile-only {
       height: 0px;
       grid-row: 2;
@@ -798,7 +805,8 @@ $atomium-bg-width: 1429px;
     column-gap: 20px;
     @include mobile-only {
       display: grid;
-      grid-row: 1 / 4;
+      grid-row-start: 1;
+      grid-row-end: 4;
       gap: 10px;
     }
     justify-self: end;


### PR DESCRIPTION
# Description
Changed approach with CSS for `<footer>` separators

|        | before | after |
|--------|--------|-------|
| desktop| ![image](https://user-images.githubusercontent.com/2574275/226595139-32806e97-f5c7-4c72-9353-fa5415a7812d.png) | ![image](https://user-images.githubusercontent.com/2574275/226595200-c12ef59a-b857-486f-84f1-dd68d1ce2e1f.png) |
| mobile | ![image](https://user-images.githubusercontent.com/2574275/226595029-9c21d824-1301-4949-998b-79e08dd5e112.png) | ![image](https://user-images.githubusercontent.com/2574275/226594926-60d3df5b-f336-4202-a170-d83b5bc2a299.png) |
## [Preview Link](https://deploy-preview-286--eurorust.netlify.app/)

# Context
This helps tackle the integration of `Submit a Talk` link in the `<footer>`.
