### PR TITLE
feat(footer): add font and font-size to bullet separators in footer

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -750,8 +750,13 @@ $atomium-bg-width: 1429px;
     }
 
     li:nth-child(n + 2)::before {
-      content: "•";
+      content: "·";
       margin-right: 10px;
+      font-family: Poppins-Light;
+      font-size: 15px;
+      @include desktop-and-tablet-only {
+        font-size: 18px;
+      }
     }
   }
 


### PR DESCRIPTION
# Description
- Replace character `•` with `·`
- Use the same font-family and font size for bullet point separators

|  | before | after |
|--|--------|-------|
| Desktop | ![image](https://user-images.githubusercontent.com/2574275/226605169-0b825f86-1547-4423-8baf-509fc7f3d75d.png) | ![image](https://user-images.githubusercontent.com/2574275/226607277-0af841fc-1e4b-4250-9341-48088d1dc8f3.png) |
| Mobile | ![image](https://user-images.githubusercontent.com/2574275/226605398-5af3527b-e417-4fb2-9c09-cbc893fd2e85.png) | ![image](https://user-images.githubusercontent.com/2574275/226607177-5bdb00ed-1508-44c9-99f2-951edc81bb97.png) |


## [Preview Link](https://deploy-preview-287--eurorust.netlify.app/)

# Context
This relates to the problem reported by @davidhajba here: https://github.com/mainmatter/eurorust.eu/pull/286#issuecomment-1477697674
