### PR TITLE
feat(sponsors): enable sponsors section with Rust Foundation as Head Partner

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,7 +1,7 @@
 +++
 [extra]
 	enable_cfp=false
-	enable_sponsors=false
+	enable_sponsors=true
 
 [extra.cfp]
 	link="#"


### PR DESCRIPTION
fixes #294