### PR TITLE
feat(sponsors): remove left alignment for partners/supporters in mobile

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -692,9 +692,8 @@ body {
 
       &.partners {
         gap: 30px;
-        justify-content: left;
+        justify-content: center;
         @include desktop-and-tablet-only {
-          justify-content: center;
           gap: 46px;
         }
         img {
@@ -704,9 +703,8 @@ body {
 
       &.supporters {
         gap: 30px;
-        justify-content: left;
+        justify-content: center;
         @include desktop-and-tablet-only {
-          justify-content: center;
           gap: 46px;
         }
         img {


### PR DESCRIPTION
# Description
Remove `alignment-left` for Supporters/Partners in Mobile screen sizes

## [Preview](https://deploy-preview-317--eurorust.netlify.app/)

# Context
fixes #316 