### PR TITLE
fix(sponsors): apply display:block to assure logos are aligned vertically centered

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -668,6 +668,7 @@ body {
       img {
         width: 100%;
         height: auto;
+        display: block;
       }
 
       &.premier-partners {


### PR DESCRIPTION
# Description
Apply `display: block` to Sponsor logos to assure there is no inferred `line-height` interfering with the centred vertical alignment

| before | after |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/2574275/233081509-95c5637e-91ce-4e3a-9800-0dadb2a0de6a.png) | ![image](https://user-images.githubusercontent.com/2574275/233081424-321a02dd-44ee-4259-8d41-194fc0d74956.png) |
| ![image](https://user-images.githubusercontent.com/2574275/233081651-e4ed444d-bf03-4840-8e9d-766cf7ddfcf8.png) | ![image](https://user-images.githubusercontent.com/2574275/233081691-d5756d57-8742-49ca-b655-8613d714899a.png) | 

# Context
fixes #318 