### PR TITLE
fix(speakers): update Niko's job title with 'Co-Lead of the Rust Language Team'

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -68,7 +68,7 @@
 [[extra.speakers]]
 	name="Niko Matsakis"
 	company="AWS"
-	job_title="Senior Principal Engineer at AWS, Member of the Rust Compiler team"
+	job_title="Senior Principal Engineer at AWS, Co-Lead of the Rust Language Team"
 	image="niko-matsakis.png"
 	twitter="nikomatsakis"
 	web="https://nick.matsakis.net/"


### PR DESCRIPTION
fixes #337 