### PR TITLE
feat(frontpage): remove 'past event highlights' from frontpage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -76,7 +76,6 @@
     </div>
     {% include "sections/topics.html" %}
     <div class="middle-block">
-      {% include "sections/past-event-highlights.html" %}
       {% include "sections/speakers.html" %}
       {% include "sections/moderators.html" %}
     </div>


### PR DESCRIPTION
# 📖 Description
[feat(frontpage): remove 'past event highlights' from frontpage](https://github.com/mainmatter/eurorust.eu/pull/358/commits/b6aa32f1c87fb0497ab0020159ace63fdff9c3d3)

## 🔬 Preview link
🔗 [Preview Link](https://deploy-preview-358--eurorust.netlify.app/)

# 📚 Context
fixes #357 