### PR TITLE
fix paragraph spacing in speaker bios

### DIFF
--- a/sass/_speaker.scss
+++ b/sass/_speaker.scss
@@ -133,6 +133,10 @@
     }
 
     .bio {
+      p + p {
+        margin-top: 40px;
+      }
+
       a {
         color: #00ffc4;
         text-decoration: underline;


### PR DESCRIPTION
| before | after |
|--------|------|
| <img width="872" alt="Bildschirmfoto 2023-07-19 um 11 29 55" src="https://github.com/mainmatter/eurorust.eu/assets/1510/05361503-a1ec-47d3-8bd7-2327ee7ebe87"> | <img width="910" alt="Bildschirmfoto 2023-07-19 um 11 29 59" src="https://github.com/mainmatter/eurorust.eu/assets/1510/1676dedd-0ff7-4b5b-bcc0-e71bbcb447f5"> |
