### PR TITLE
fix code formatting in workshop

### DIFF
--- a/content/workshops/you-cant-fix-what-you-cant-see-telemetry-for-rust-apis.md
+++ b/content/workshops/you-cant-fix-what-you-cant-see-telemetry-for-rust-apis.md
@@ -21,19 +21,19 @@ This workshop is designed for developers who are operating Rust services in prod
 <ul>
 	<li>
 		<p>Structured logging (tracing)</p>
-		<p>An introduction to the `tracing` instrumentation library, covering both how to instrument your code (capturing fields, log levels, macros) and how to process the resulting telemetry data in your application (subscriber configuration, logging levels, log filtering).</p>
+		<p>An introduction to the <code>tracing</code> instrumentation library, covering both how to instrument your code (capturing fields, log levels, macros) and how to process the resulting telemetry data in your application (subscriber configuration, logging levels, log filtering).</p>
 	</li>
 	<li>
 		<p>Error handling</p>
-		<p>We will cover Rust’s `Error` trait, with a focus on the information that can be retrieved and recorded in your logs; we will also spend some time on logging patterns (e.g. when should an error be logged?) and relevant libraries for error handling (anyhow/thiserror).</p>
+		<p>We will cover Rust’s <code>Error</code> trait, with a focus on the information that can be retrieved and recorded in your logs; we will also spend some time on logging patterns (e.g. when should an error be logged?) and relevant libraries for error handling (anyhow/thiserror).</p>
 	</li>
 	<li>
 		<p>Panic handling</p>
-		<p>You should always manage to capture details about what went wrong, even if it’s due to an uncaught panic rather than an error. We will review panic hooks and integrate them in our `tracing` setup.</p>
+		<p>You should always manage to capture details about what went wrong, even if it’s due to an uncaught panic rather than an error. We will review panic hooks and integrate them in our <code>tracing</code> setup.</p>
 	</li>
 	<li>
 		<p>Metrics, both for application and runtime (tokio-metrics)</p>
-		<p>Structured logs are important, but they don’t tell the full story. We will look at how to capture metric data using the `metrics` library, as a tool for designing alarms as well troubleshooting faulty behaviour. We will spend some time on `tokio-metrics` and how to interpret the data it shows with respect to your `tokio` runtime usage.</p>
+		<p>Structured logs are important, but they don’t tell the full story. We will look at how to capture metric data using the <code>metrics</code> library, as a tool for designing alarms as well troubleshooting faulty behaviour. We will spend some time on <code>tokio-metrics</code> and how to interpret the data it shows with respect to your <code>tokio</code> runtime usage.</p>
 	</li>
 </ul>
 <h4>Prerequisites</h4>


### PR DESCRIPTION
backticks are currently displayed as they are:

<img width="732" alt="Bildschirmfoto 2023-08-16 um 14 38 27" src="https://github.com/mainmatter/eurorust.eu/assets/1510/96580944-7e6f-469b-a086-0febf4abeb0e">
