### PR TITLE
feat(sponsors): set a height of 57px to gensyn logo in sponsors.html

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -631,6 +631,13 @@ body {
         display: block;
       }
 
+      img.gensyn {
+        @include desktop-and-tablet-only {
+          height: 57px;
+        }
+        height: 48px;
+      }
+
       &.premier-partners {
         gap: 39px;
         @include desktop-and-tablet-only {
@@ -676,7 +683,8 @@ body {
   }
 }
 
-.venue, .workshop-venue {
+.venue,
+.workshop-venue {
   display: grid;
   text-align: center;
   align-items: center;


### PR DESCRIPTION
# Description
Set a hardcoded `height` for `gensyn` logo

| before | after |
|--------|--------|
| <img width="755" alt="image" src="https://github.com/mainmatter/eurorust.eu/assets/2574275/06e5c313-8d34-4d0e-bd32-fc6fccc05fa7"> | <img width="777" alt="image" src="https://github.com/mainmatter/eurorust.eu/assets/2574275/e5cfe1ad-a736-4a00-b988-2e9338f01688"> | 
| <img width="436" alt="image" src="https://github.com/mainmatter/eurorust.eu/assets/2574275/fdd3306e-77fc-46aa-9847-a79f17dcaad2"> | <img width="451" alt="image" src="https://github.com/mainmatter/eurorust.eu/assets/2574275/1cf33d94-f7d1-4d9c-afbe-4b3956ab9b99"> |

# Contex
Resolves #397 