### PR TITLE
fix(sponsors): add a max-height for supporters

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -678,6 +678,7 @@ body {
         }
         img {
           max-width: var(--max-width-supporters);
+          max-height: 80px;
         }
       }
     }


### PR DESCRIPTION
# 📖 Description
Add a `max-height` for supporter logos

## [Preview Link 🔗 ](https://deploy-preview-410--eurorust.netlify.app/)

# 📚 Context
| before | after |
|--------|--------|
|<img width="1458" alt="image" src="https://github.com/mainmatter/eurorust.eu/assets/2574275/0b0b04a4-976c-4f63-b912-beeb224b9208"> | <img width="1462" alt="image" src="https://github.com/mainmatter/eurorust.eu/assets/2574275/86da02ba-cec7-4ee2-8fd2-9a6e5031c1dc"> | 