### PR TITLE
link "presented by Mainmatter" to our Rust landing page

### DIFF
--- a/templates/2022/partials/footer.html
+++ b/templates/2022/partials/footer.html
@@ -4,7 +4,7 @@
     <p class="copy">&copy; 2022 Events Matter UG</p>
     <p class="presented">
       Presented by
-      <a href="https://mainmatter.com"><img src="/2022/images/mainmatter-logo-negative.svg" alt="Mainmatter logo" /></a>
+      <a href="https://mainmatter.com/rust-consulting/"><img src="/2022/images/mainmatter-logo-negative.svg" alt="Mainmatter logo" /></a>
     </p>
     
   </div>

--- a/templates/2022/sections/sponsors.html
+++ b/templates/2022/sections/sponsors.html
@@ -1,7 +1,7 @@
 <section class="sponsors">
   <h1 class="title">
     Presented by
-    <a href="https://mainmatter.com" alt="Mainmatter website">
+    <a href="https://mainmatter.com/rust-consulting/" alt="Mainmatter website">
       <img src="/2022/images/mainmatter-logo.svg" alt="Mainmatter logo" />
     </a>
   </h1>

--- a/templates/2023/partials/footer.html
+++ b/templates/2023/partials/footer.html
@@ -5,7 +5,7 @@
     </li>
     <li>
       <a
-        href="/2023"
+        href="https://mainmatter.com/rust-consulting/"
         target="_blank"
         rel="noopener noreferrer">Presented by Mainmatter</a>
     </li>

--- a/templates/2023/sections/presented-by.html
+++ b/templates/2023/sections/presented-by.html
@@ -1,5 +1,5 @@
 <section class="presented-by">
 	<p class="light-font">Presented by</p>
-	<a href="/2023/" target="_blank" rel="noopener noreferrer"><img
+	<a href="https://mainmatter.com/rust-consulting/" target="_blank" rel="noopener noreferrer"><img
 			src="/2023/images/mainmatter-logo-negative.svg" alt="mainmatter logo"></a>
 </section>

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -5,7 +5,7 @@
     </li>
     <li>
       <a
-        href="https://mainmatter.com"
+        href="https://mainmatter.com/rust-consulting/"
         target="_blank"
         rel="noopener noreferrer">Presented by Mainmatter</a>
     </li>

--- a/templates/sections/presented-by.html
+++ b/templates/sections/presented-by.html
@@ -1,5 +1,5 @@
 <section class="presented-by">
 	<p class="light-font">Presented by</p>
-	<a href="https://mainmatter.com" target="_blank" rel="noopener noreferrer"><img
+	<a href="https://mainmatter.com/rust-consulting/" target="_blank" rel="noopener noreferrer"><img
 			src="/images/mainmatter-logo-negative.svg" alt="mainmatter logo"></a>
 </section>


### PR DESCRIPTION
Some of those links were also linked to /2022 and /2023 by mistake so this fixes that as well.