### PR TITLE
fix headline on cancellation page

### DIFF
--- a/content/cancellation.md
+++ b/content/cancellation.md
@@ -7,7 +7,7 @@ title = "Cancellation up to 30 Days Before the Conference"
   <p>Up to 30 days before the start of the conference, you can get a full refund for your ticket. Send an email to <a href="mailto:mail@eurorust.eu">mail@eurorust.eu</a> and we will process your refund.</p>
 </div>
 
-<h3 class="mb-3 mt-7">Cancellation up to 30 Days Before the Conference</h3>
+<h3 class="mb-3 mt-7">Cancellation within 30 Days Before the Conference</h3>
 <div class="box">
   <p>We are unable to offer refunds within 30 days of the conference, however your ticket can be reassigned at any time to a different attendee. To reassign your ticket, please follow the link on your original confirmation email.</p>
 </div>


### PR DESCRIPTION
closes #509 

![Bildschirmfoto 2024-07-18 um 15 52 06](https://github.com/user-attachments/assets/09d48c24-13b5-4eed-ba98-80cd51c416c5)
