### PR TITLE
prevent horizontal scroll on mobile

### DIFF
--- a/sass/components/_speakers.scss
+++ b/sass/components/_speakers.scss
@@ -58,8 +58,8 @@
     position: absolute;
     top: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
+    width: calc(100% - 1.5rem);
+    height: calc(100% - 1.5rem);
     border: 2px solid var(--white);
     transform: translate(1.5rem, -1.5rem);
     z-index: -1;
@@ -69,8 +69,8 @@
     position: absolute;
     top: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
+    width: calc(100% - 1.5rem);
+    height: calc(100% - 1.5rem);
     opacity: 0.7;
     background-image: linear-gradient(65deg, #59decb 0%, #3b63e7 60%, #de59cc 100%);
     mix-blend-mode: color;
@@ -78,8 +78,8 @@
 
   img {
     display: block;
-    width: 100%;
-    height: 100%;
+    width: calc(100% - 1.5rem);
+    height: calc(100% - 1.5rem);
   }
 }
 


### PR DESCRIPTION
This fixes speaker etc. images leaving the viewport which also causes horizontal scrolling, at least in Safari.

| Before | After |
|--------|------|
| ![IMG_3400](https://github.com/user-attachments/assets/604672e8-8344-4fda-a9b5-b7ef9fe37af3) | ![IMG_3399](https://github.com/user-attachments/assets/cb85db52-43a7-434a-8c22-3b62c0969e43) |
