### PR TITLE
Fix broken styling 2024

### DIFF
--- a/sass/2024/typography.scss
+++ b/sass/2024/typography.scss
@@ -84,6 +84,7 @@ a {
   text-decoration-thickness: 0.125rem;
   text-underline-offset: 4px;
   -webkit-text-fill-color: rgba(255, 255, 255, 1);
+  color: #fff;
 
   &:hover {
     text-decoration-color: #fff;

--- a/static/2024/js/script.js
+++ b/static/2024/js/script.js
@@ -22,7 +22,7 @@ const gltfLoader = new GLTFLoader();
 let model = new THREE.Object3D();
 let ferris = new THREE.Object3D();
 
-gltfLoader.load('/js/model/ferris.glb', (gltf) => {
+gltfLoader.load('2024/js/model/ferris.glb', (gltf) => {
   model = gltf.scene;
   ferris = gltf.scene.children[0];
   ferris.scale.set(1.5, 1.5, 1.5);


### PR DESCRIPTION
This fixes two bits of styling that got broken in /2024:

- Ferris model in hero
- Inline links text-decoration color (from blue to original white)